### PR TITLE
OTC-1062: manage policy dates when it is payed

### DIFF
--- a/contribution/gql_mutations.py
+++ b/contribution/gql_mutations.py
@@ -92,7 +92,7 @@ def update_or_create_premium(data, user):
         if data["pay_date"] > policy.start_date:
             days_delayed = policy.enroll_date - policy.start_date
             policy.start_date = policy.enroll_date
-            policy.expiry_date = policy.enroll_date + days_delayed
+            policy.expiry_date = policy.start_date + days_delayed
         policy.save()
     if premium_uuid:
         premium = Premium.objects.get(uuid=premium_uuid)


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OTC-1062

Changes:
1. Effective date is equal to payment day of contribution (last payment when a balance became 0)
2. Start date is Enrolment Date if the policy is payed later
3. Expiry date relay on Start date and is postponed as the Start date is